### PR TITLE
Add support for flathubbot external data checker

### DIFF
--- a/org.scummvm.ScummVM.json
+++ b/org.scummvm.ScummVM.json
@@ -20,7 +20,8 @@
         "/lib/pkgconfig",
         "/share/aclocal",
         "/share/man",
-        "*.la", "*.a"
+        "*.la",
+        "*.a"
     ],
     "modules": [
         "shared-modules/libmad/libmad.json",
@@ -32,7 +33,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://http.debian.net/debian/pool/main/f/fluid-soundfont/fluid-soundfont_3.1.orig.tar.gz",
+                    "url": "http://deb.debian.org/debian/pool/main/f/fluid-soundfont/fluid-soundfont_3.1.orig.tar.gz",
                     "sha256": "2621acaa1c78e4abdb24bdd163230cc577e61276936d6aa6e3180582142f0343",
                     "x-checker-data": {
                         "type": "anitya",
@@ -51,8 +52,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://sourceforge.net/projects/faac/files/faad2-src/faad2-2.8.0/faad2-2.8.8.tar.gz",
-                    "sha256": "985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d",
+                    "url": "https://github.com/knik0/faad2/archive/2.10.1.tar.gz",
+                    "sha256": "4c16c71295ca0cbf7c3dfe98eb11d8fa8d0ac3042e41604cfd6cc11a408cf264",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 13755,
@@ -66,7 +67,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz",
+                    "url": "https://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz",
                     "sha256": "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4",
                     "x-checker-data": {
                         "type": "anitya",
@@ -76,7 +77,9 @@
                 },
                 {
                     "type": "shell",
-                    "commands": ["cp /usr/share/gnu-config/config.{guess,sub} .auto/"]
+                    "commands": [
+                        "cp /usr/share/gnu-config/config.{guess,sub} .auto/"
+                    ]
                 }
             ]
         },
@@ -85,7 +88,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://liba52.sourceforge.net/files/a52dec-0.7.4.tar.gz",
+                    "url": "https://liba52.sourceforge.net/files/a52dec-0.7.4.tar.gz",
                     "sha256": "a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33",
                     "x-checker-data": {
                         "type": "anitya",
@@ -95,7 +98,9 @@
                 },
                 {
                     "type": "shell",
-                    "commands": ["cp /usr/share/gnu-config/config.{guess,sub} ./autotools"]
+                    "commands": [
+                        "cp /usr/share/gnu-config/config.{guess,sub} ./autotools"
+                    ]
                 }
             ]
         },

--- a/org.scummvm.ScummVM.json
+++ b/org.scummvm.ScummVM.json
@@ -33,7 +33,12 @@
                 {
                     "type": "archive",
                     "url": "http://http.debian.net/debian/pool/main/f/fluid-soundfont/fluid-soundfont_3.1.orig.tar.gz",
-                    "sha256": "2621acaa1c78e4abdb24bdd163230cc577e61276936d6aa6e3180582142f0343"
+                    "sha256": "2621acaa1c78e4abdb24bdd163230cc577e61276936d6aa6e3180582142f0343",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 117393,
+                        "url-template": "http://deb.debian.org/debian/pool/main/f/fluid-soundfont/fluid-soundfont_$version.orig.tar.gz"
+                    }
                 }
             ],
             "buildsystem": "simple",
@@ -47,7 +52,12 @@
                 {
                     "type": "archive",
                     "url": "https://sourceforge.net/projects/faac/files/faad2-src/faad2-2.8.0/faad2-2.8.8.tar.gz",
-                    "sha256": "985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d"
+                    "sha256": "985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13755,
+                        "url-template": "https://github.com/knik0/faad2/archive/$version.tar.gz"
+                    }
                 }
             ]
         },
@@ -57,7 +67,12 @@
                 {
                     "type": "archive",
                     "url": "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz",
-                    "sha256": "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
+                    "sha256": "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 21490,
+                        "url-template": "https://libmpeg2.sourceforge.net/files/libmpeg2-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "shell",
@@ -71,7 +86,12 @@
                 {
                     "type": "archive",
                     "url": "http://liba52.sourceforge.net/files/a52dec-0.7.4.tar.gz",
-                    "sha256": "a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33"
+                    "sha256": "a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13972,
+                        "url-template": "https://liba52.sourceforge.net/files/a52dec-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "shell",
@@ -102,7 +122,12 @@
                 {
                     "type": "archive",
                     "url": "https://downloads.scummvm.org/frs/scummvm/2.7.1/scummvm-2.7.1.tar.bz2",
-                    "sha256": "dd303fc56805a4bc7c69990add566e149a0c3002f5c0e87df876c58e6b8df8cc"
+                    "sha256": "dd303fc56805a4bc7c69990add566e149a0c3002f5c0e87df876c58e6b8df8cc",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 4775,
+                        "url-template": "https://downloads.scummvm.org/frs/scummvm/$version/scummvm-$version.tar.bz2"
+                    }
                 },
                 {
                     "type": "file",

--- a/org.scummvm.ScummVM.json
+++ b/org.scummvm.ScummVM.json
@@ -26,20 +26,7 @@
         "shared-modules/libmad/libmad.json",
         "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",
-        {
-            "name": "fluidsynth",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.1.9.tar.gz",
-                    "sha256": "365642cc64bafe0491149ad643ef7327877f99412d5abb93f1fa54e252028484"
-                }
-            ],
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DLIB_INSTALL_DIR=lib"
-            ]
-        },
+        "shared-modules/linux-audio/fluidsynth2.json",
         {
             "name": "fluid_soundfont",
             "sources": [


### PR DESCRIPTION
As a proposal I performed this changes:

1. Moved **fluidsynth2** module to use the `shared-modules` one and updated the `shared-modules` to the latest commit.
2. Added the `x-checker-data` to the rest of flatpak modules so FlathubBot can create automatic pull requests.
3. Run the [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) to update all modules to the latest version (including some minor JSON lint perform by the tool)

Note that in order to allow FlathubBot to automatically merge its own PRs (if they succeed) it is required to add the file `flathub.json` with:
```json
{
  "automerge-flathubbot-prs": true
}
```

If you want I can also add this in this PR, or you can add it later in a separated PR.

Also now flatpak supports both JSON and YAML, if you prefer to switch the manifest to YAML I can add another commit with that, both are ok for me, whatever suits best for you.