### PR TITLE
Add optionally window CSD in wayland

### DIFF
--- a/org.scummvm.ScummVM.json
+++ b/org.scummvm.ScummVM.json
@@ -23,6 +23,7 @@
         "*.la", "*.a"
     ],
     "modules": [
+        "shared-modules/SDL2/SDL2-with-libdecor.json",
         "shared-modules/libmad/libmad.json",
         "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",


### PR DESCRIPTION
Add SDL2 with [libdecor](https://gitlab.freedesktop.org/libdecor/libdecor/) to show window decorations inside wayland GNOME desktop.