### PR TITLE
Enable sdlnet

### DIFF
--- a/org.scummvm.ScummVM.json
+++ b/org.scummvm.ScummVM.json
@@ -124,7 +124,6 @@
             ],
             "config-opts": [
                 "--enable-release",
-                "--disable-sdlnet",
                 "--disable-debug",
                 "--disable-system-dialogs"
             ],


### PR DESCRIPTION
This PR is to enable sdlnet, I just assumed it was disabled before because the freedesktop 22.08 runtime didn't came with it preinstalled.

Since PR #36 has been merged and libsdl-net is now available inside the freedesktop 23.08 runtime, this can now be enabled.

Also I have seen that the permission `--share=network` is already present,
but I don't know what kind of usage of it does the ScummVM,
so not sure either on the benefits of having libsdl-net enabled or how to test it.