### PR TITLE
Give ScummVM full home dir access

### DIFF
--- a/org.scummvm.ScummVM.json
+++ b/org.scummvm.ScummVM.json
@@ -10,8 +10,7 @@
         "--socket=x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--filesystem=xdg-documents",
-        "--filesystem=xdg-pictures"
+        "--filesystem=home"
     ],
     "command": "scummvm_wrapper",
     "rename-icon": "org.scummvm.scummvm",


### PR DESCRIPTION
This will make the ScummVM Flatpak less sandboxed, but will make it much more straightforward to use for end-users without forcing them to copy the game files into xdg-documents.

ScummVM config and save files will continue to stay inside the Flatpak app directory since ScummVM already supports XDG base directories for this, so there will be no breakage for existing users.

Also, the ScummVM 2.8.0 Flatpak no longer mentions the sandbox limitation in its AppStream metadata (since it uses the upstream version of the metainfo file instead of a bundled downstream one).

@lotharsm Is this ok to be merged (after it gets tested)?